### PR TITLE
#165427404 PR to add endpoint to retrieve active accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,15 @@
 ##### Documentation - https://documenter.getpostman.com/view/938650/S1ENxJKx
 
 ### Test User Accounts
-#### Admin
-email - `tylerross@gmail.com`
-password - `tylerross`
-
-#### Staff
-email - `johnwayne@gmail.com`
-password - `johnwayne`
-
-#### Client
-email - `jamesdonovan@gmail.com`
-password - `jamesdonovan`
+|          Email         |    Password   | Account Type |
+| ---------------------- | ------------- | ------------ |
+| tylerross@gmail.com    |    tylerross  |     admin    |
+| johnwayne@gmail.com    |    johnwayne  |     staff    |
+| jamesdonovan@gmail.com |  jamesdonovan |     client   |
 
 ### Test Bank Accounts
-Account Number - `2869502843` status - `draft`
 
-Account Number - `2816408925` status - `active`
+| Account Number |    status     |
+| -------------- | ------------- |
+|   2869502843   |     draft     |
+|   2816408925   |     active    |

--- a/test/account.js
+++ b/test/account.js
@@ -84,6 +84,20 @@ describe('/GET, POST and /PATCH acccounts', () => {
     });
   });
 
+  describe('/GET Active accounts', () => {
+    it('it should retrieve all accounts that have an active status', (done) => {
+      chai.request(server)
+        .get('/v1/accounts?status=active')
+        .set('Authorization', token)
+        .end((err, res) => {
+          res.should.have.a.status(200);
+          expect(res.body.data.length).to.be.above(0);
+          expect(res.body.data[0].status).to.be.equal('active');
+          done();
+        });
+    });
+  });
+
   describe('/PATCH accounts', () => {
     it('it should patch account and return status of 200', (done) => {
       chai.request(server)


### PR DESCRIPTION
### What this PR does
- It implements an endpoint to retrieve active accounts
#### Description of Task to be completed
- create a test for endpoint
#### How it should be tested
 - follow the README.md guidelines to set up and run the application
 - use Postman to test the following endpoints:
`GET localhost:9000/v1/accounts?status=active` for all active accounts
 - For authentication, use any of the test user accounts in the README documentation for login with this endpoint:
`POST localhost:9000/v1/auth/signin`
 - Use the bearer token option in the authentication tab. Supply the token generated.
#### Relevant pivotal tracker story
- [Delivers #165427404]