### PR TITLE
#165427301 PR to add user can get specific account details feature

### DIFF
--- a/database/controllers/account.js
+++ b/database/controllers/account.js
@@ -20,7 +20,17 @@ const accountController = {
 
   getUserAccounts: accountNumber => new Promise((resolve, reject) => {
     account.findOneByAccountNo(accountNumber)
-      .then(data => resolve(Object.assign({}, { status: 200, data })))
+      .then((data) => {
+        const output = data.map(accountData => ({
+          createdOn: accountData.createdon,
+          accountNumber: accountData.accountnumber,
+          ownerEmail: accountData.email,
+          type: accountData.type,
+          status: accountData.status,
+          balance: accountData.balance,
+        }));
+        resolve(Object.assign({}, { status: 200, data: output }));
+      })
       .catch(error => reject(Object.assign({}, { status: 404, error })));
   }),
 

--- a/database/controllers/transaction.js
+++ b/database/controllers/transaction.js
@@ -24,6 +24,7 @@ const transactionController = {
         transactionType: payload.type,
         accountBalance: String(updatedTransaction[1].balance),
       };
+      // console.log('CLIENT PAYLOAD: ', clientPayload);
       return Object.assign({}, { status: 200, data: clientPayload });
     } catch (e) {
       if (e.message) throw new Error(e.message);

--- a/database/models/account.js
+++ b/database/models/account.js
@@ -69,7 +69,11 @@ const Account = {
 
   findOneByAccountNo(accountNumber) {
     return new Promise((resolve, reject) => {
-      const queryText = `SELECT * FROM Accounts WHERE accountNumber=${accountNumber};`;
+      const queryText = `SELECT
+          Accounts.id, accountNumber, createdOn, email, Accounts.type, Accounts.status, balance
+        FROM Accounts
+        LEFT JOIN Users
+        ON Users.id = Accounts.owner WHERE accountNumber=${accountNumber};`;
       queryDb.query(queryText)
         .then((res) => {
           resolve(res.rows);

--- a/database/models/transaction.js
+++ b/database/models/transaction.js
@@ -34,7 +34,7 @@ const Transaction = {
         id: makeTransactionId(),
         createdOn: returnCurrentDateTime(),
         type: payload.type,
-        accountNumber: accountInformation.accountnumber,
+        accountNumber: accountInformation.accountNumber,
         cashier: payload.cashier,
         amount: Number(payload.amount),
         oldBalance: Number(oldBalance.toFixed(2)),

--- a/test/account.js
+++ b/test/account.js
@@ -70,6 +70,19 @@ describe('/GET, POST and /PATCH acccounts', () => {
     });
   });
 
+  describe('/GET a specific account', () => {
+    it('it should retrieve a specific account using the accNo and return status of 200', (done) => {
+      chai.request(server)
+        .get('/v1/accounts/281640892')
+        .set('Authorization', token)
+        .end((err, res) => {
+          res.should.have.a.status(200);
+          expect(res.body.data.length).to.be.above(0);
+          done();
+        });
+    });
+  });
+
   describe('/GET Dormant accounts', () => {
     it('it should retrieve all accounts that have dormant status', (done) => {
       chai.request(server)


### PR DESCRIPTION
### What this PR does
- It implements an endpoint to get a specific bank account detail
#### Description of Task to be completed
- modified data query in models
- updated existing controller to format endpoint data
- created test for endpoint
- fixed broken tests related to transactions
#### How it should be tested
 - follow the README.md guidelines to set up and run the application
 - use Postman to test the following endpoints:
`GET localhost:9000/v1/accounts/:accountNumber` for a specific account
 - For authentication, use any of the test user accounts in the README documentation for login with this endpoint:
`POST localhost:9000/v1/auth/signin`
 - Use the bearer token option in the authentication tab. Supply the token generated.
#### Relevant pivotal tracker story
- [Delivers #165427301]