### PR TITLE
#165427245 PR to add endpoint to retrieve a specific transaction

### DIFF
--- a/database/controllers/transaction.js
+++ b/database/controllers/transaction.js
@@ -8,7 +8,18 @@ const transactionController = {
     .catch(error => reject(Object.assign({}, { status: 404, error })))),
 
   getOneTransaction: id => new Promise((resolve, reject) => transaction.findOneById(id)
-    .then(data => resolve(Object.assign({}, { status: 200, data })))
+    .then((data) => {
+      const response = data.map(tx => ({
+        transactionId: tx.id,
+        createdOn: tx.createdon,
+        type: tx.type,
+        accountNumber: tx.accountnumber,
+        amount: tx.amount,
+        oldBalance: tx.oldbalance,
+        newBalance: tx.newbalance,
+      }));
+      resolve(Object.assign({}, { status: 200, data: response }));
+    })
     .catch(error => reject(Object.assign({}, { status: 404, error })))),
 
   createTransaction: async (payload) => {

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -99,7 +99,7 @@ describe('/POST and /GET transactions', () => {
         .set('Authorization', token)
         .end((err, res) => {
           res.should.have.a.status(200);
-          expect(res.body.data[0].id).to.be.equal(612879);
+          expect(res.body.data[0].transactionId).to.be.equal(612879);
           done();
         });
     });
@@ -130,7 +130,7 @@ describe('/POST and /GET transactions', () => {
   });
 
   after((done) => {
-    console.log('Action after Tests');
+    console.log('Action after Tests', transactionIds);
     account.deleteBankAccount(createdAccount.accountNumber)
       .then(() => transactionIds.map(id => transaction.deleteTransaction(id)))
       .then((transactionRes) => {


### PR DESCRIPTION
### What this PR does
- It implements an endpoint to retrieve a specific transaction
#### Description of Task to be completed
- modified controller to format data
- fixed existing failing test
#### How it should be tested
 - follow the README.md guidelines to set up and run the application
 - use Postman to test the following endpoints:
`GET localhost:9000/v1/transactions/:id` for a specific transaction
 - For authentication, use any of the test user accounts in the README documentation for login with this endpoint:
`POST localhost:9000/v1/auth/signin`
 - Use the bearer token option in the authentication tab. Supply the token generated.
#### Relevant pivotal tracker story
- [Delivers #165427245]